### PR TITLE
fix(DDocument): long read problem

### DIFF
--- a/src/main/java/ovis/futureplots/components/provider/client/components/DDocument.java
+++ b/src/main/java/ovis/futureplots/components/provider/client/components/DDocument.java
@@ -70,7 +70,7 @@ public class DDocument {
     }
 
     public long getLong(String key) {
-        return (long) this.data.get(key);
+        return ((Number) this.data.get(key)).longValue();
     }
 
     public List<String> getStringList(String key) {


### PR DESCRIPTION
When reading a relatively small value, the int type will be returned. Here, the longValue method is used to solve this problem.