### PR TITLE
fix: add connection timeouts for GitHub API calls

### DIFF
--- a/src/main/java/ovis/futureplots/components/util/UpdateChecker.java
+++ b/src/main/java/ovis/futureplots/components/util/UpdateChecker.java
@@ -156,6 +156,8 @@ public class UpdateChecker {
             URL url = new URL(urlString);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
 
             BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
             String inputLine;


### PR DESCRIPTION
fix the issue where the server gets stuck if access to GitHub fails